### PR TITLE
Fix collection and to_dict of MapAttribute in model

### DIFF
--- a/falcano/attributes.py
+++ b/falcano/attributes.py
@@ -653,13 +653,13 @@ class MapAttribute(Attribute[Mapping[_KT, _VT]], AttributeContainer):
                 local_attr.update_attribute_paths(path_segment)
 
     def __eq__(self, other):
-        # if self._is_attribute_container():
-        #     return AttributeContainer.__eq__(self, other)
+        if self._is_attribute_container():
+            return AttributeContainer.__eq__(self, other)
         return Attribute.__eq__(self, other)
 
     def __ne__(self, other):
-        # if self._is_attribute_container():
-        #     return AttributeContainer.__ne__(self, other)
+        if self._is_attribute_container():
+            return AttributeContainer.__ne__(self, other)
         return Attribute.__ne__(self, other)
 
     def __iter__(self):

--- a/falcano/model.py
+++ b/falcano/model.py
@@ -154,6 +154,7 @@ class Model(metaclass=MetaModel):
             attributes[self.get_range_key().attr_name] = range_key
         self.attribute_values: Dict[str, Any] = {}
         self.initialize_attributes(_user_instantiated, **attributes)
+        self.convert_decimal = True
 
     class Meta():
         '''
@@ -749,8 +750,10 @@ class Model(metaclass=MetaModel):
         data = table.put_item(**kwargs)
         return data
 
-    def to_dict(self, primary_key: str = 'PK'):
+    def to_dict(self, primary_key: str = 'PK', convert_decimal: bool = True):
         '''Convert a pynamo model into a dictionary for JSON serialization'''
+        # temporary override of converting decimal to int/float
+        self.convert_decimal = convert_decimal
         ret_dict = {}
         for name, attr in self.attribute_values.items():
             ret_dict[name] = self._attr2obj(attr)

--- a/falcano/paginator.py
+++ b/falcano/paginator.py
@@ -90,7 +90,7 @@ class Results:
             id_attr = primary_key
 
         # Get the item as a dict, set the ID to id_attr attribute
-        item = record.to_dict(primary_key=id_attr)
+        item = record.to_dict(primary_key=id_attr, convert_decimal=True)
 
         # New thing found, make it a dict
         if item_type not in output:

--- a/tests/integration/test_map_attribute.py
+++ b/tests/integration/test_map_attribute.py
@@ -1,0 +1,73 @@
+import unittest
+from datetime import datetime
+from decimal import Decimal
+from botocore.exceptions import ClientError
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from falcano.model import Model
+from falcano.attributes import (
+    UnicodeAttribute,
+    UTCDateTimeAttribute,
+    NumberAttribute,
+    ListAttribute,
+    UnicodeSetAttribute,
+    MapAttribute,
+)
+from falcano.indexes import GlobalSecondaryIndex, AllProjection
+
+
+class TestModel(Model):
+    '''Test model with meta'''
+    class Meta(Model.Meta):
+        table_name = 'falcano-e2e'
+        billing_mode = 'PAY_PER_REQUEST'
+    PK = UnicodeAttribute(hash_key=True)
+    SK = UnicodeAttribute(range_key=True)
+    Data = MapAttribute()
+    Type = UnicodeAttribute(default='test_map_attribute')
+
+class TestMapAttribute(unittest.TestCase):
+    def setUp(self):
+        self.monkeypatch = MonkeyPatch()
+        self.monkeypatch.setenv('AWS_ACCESS_KEY_ID', 'fakeMyKeyId')
+        self.monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'fakeMySecret')
+        if not TestModel.exists():
+            TestModel.create_table(wait=True)
+
+        for item in TestModel.scan():
+            # clean up all items in db
+            item.delete()
+
+    def tearDown(self):
+        # clean up all items in db
+        for item in TestModel.scan():
+            item.delete()
+
+    def test_existence(self):
+        test_dict = {
+            'foo': 'bar',
+            'baz': {
+                'quux': 10,
+            }
+        }
+        model = TestModel('test_map_attribute#A', 'test_map_attribute#B', Data=test_dict)
+        model.save()
+
+        res = TestModel.query('test_map_attribute#A', TestModel.SK.eq('test_map_attribute#B'))
+        collected = res.collection()
+        assert collected == {
+            'test_map_attribute': {
+                'Type': 'test_map_attribute',
+                'SK': 'test_map_attribute#B',
+                'Data': {'baz': {'quux': 10}, 'foo': 'bar'},
+                'PK': 'test_map_attribute#A',
+                'ID': 'A'
+            }
+        }
+        assert isinstance(collected['test_map_attribute']['Data']['baz']['quux'], int)
+
+        res.reset()
+        for item in res:
+            converted = item.to_dict(convert_decimal=False)
+
+        assert isinstance(converted['Data']['baz']['quux'], Decimal)

--- a/tests/unit/test_map_attribute.py
+++ b/tests/unit/test_map_attribute.py
@@ -1,0 +1,168 @@
+import json
+from falcano.model import Model
+from falcano.attributes import MapAttribute, NumberAttribute, UnicodeAttribute
+
+class TestModel(Model):
+    test_map = MapAttribute(attr_name="test_name", default={})
+
+class TestCustomAttrMap(MapAttribute):
+    overridden_number_attr = NumberAttribute(attr_name="number_attr")
+    overridden_unicode_attr = UnicodeAttribute(attr_name="unicode_attr")
+
+class TestDefaultsMap(MapAttribute):
+    map_field = MapAttribute(default={})
+    string_field = UnicodeAttribute(null=True)
+
+def test_map_overridden_attrs_accessors():
+    attr = TestCustomAttrMap(**{
+        'overridden_number_attr': 10,
+        'overridden_unicode_attr': "Hello"
+    })
+    assert attr.overridden_number_attr == 10
+    assert attr.overridden_unicode_attr == "Hello"
+
+def test_map_overridden_attrs_serialize():
+    attribute = {
+        'overridden_number_attr': 10,
+        'overridden_unicode_attr': "Hello"
+    }
+    expected = {'number_attr': {'N': 10}, 'unicode_attr': {'S': 'Hello'}}
+    assert TestCustomAttrMap().serialize(attribute) == expected
+
+def test_additional_attrs_deserialize():
+    raw_data = {
+        'number_attr': {
+            'N': '10'},
+        'unicode_attr': {
+            'S': 'Hello'
+        },
+        'undeclared_attr': {
+            'S': 'Goodbye'
+        }
+    }
+    expected = {
+        'overridden_number_attr': 10,
+        'overridden_unicode_attr': "Hello"
+    }
+    assert TestCustomAttrMap().deserialize(raw_data).attribute_values == expected
+
+def test_null_attribute_subclassed_map():
+    null_attribute = {
+        'map_field': None
+    }
+    attr = TestDefaultsMap()
+    serialized = attr.serialize(null_attribute)
+    assert serialized == {}
+
+def test_null_attribute_map_after_serialization():
+    null_attribute = {
+        'string_field': '',
+    }
+    attr = TestDefaultsMap()
+    serialized = attr.serialize(null_attribute)
+    assert serialized == {}
+
+def test_defaults():
+    item = TestDefaultsMap()
+    assert item.validate()
+    assert TestDefaultsMap().serialize(item) == {
+        'map_field': {
+            'M': {}
+        }
+    }
+
+def test_raw_set_attr():
+    item = TestModel()
+    item.test_map = {}
+    item.test_map.foo = 'bar'
+    item.test_map.num = 3
+    item.test_map.nested = {'nestedfoo': 'nestedbar'}
+
+    assert item.test_map['foo'] == 'bar'
+    assert item.test_map['num'] == 3
+    assert item.test_map['nested']['nestedfoo'] == 'nestedbar'
+
+def test_raw_set_item():
+    item = TestModel()
+    item.test_map = {}
+    item.test_map['foo'] = 'bar'
+    item.test_map['num'] = 3
+    item.test_map['nested'] = {'nestedfoo': 'nestedbar'}
+
+    assert item.test_map['foo'] == 'bar'
+    assert item.test_map['num'] == 3
+    assert item.test_map['nested']['nestedfoo'] == 'nestedbar'
+
+def test_raw_map_from_dict():
+    item = TestModel(
+        test_map={
+            "foo": "bar",
+            "num": 3,
+            "nested": {
+                "nestedfoo": "nestedbar"
+            }
+        }
+    )
+
+    assert item.test_map['foo'] == 'bar'
+    assert item.test_map['num'] == 3
+
+def test_raw_map_json_serialize():
+    raw = {
+        "foo": "bar",
+        "num": 3,
+        "nested": {
+            "nestedfoo": "nestedbar"
+        }
+    }
+
+    serialized_raw = json.dumps(raw, sort_keys=True)
+    serialized_attr_from_raw = json.dumps(
+        TestModel(test_map=raw).test_map.as_dict(),
+        sort_keys=True)
+    serialized_attr_from_map = json.dumps(
+        TestModel(test_map=MapAttribute(**raw)).test_map.as_dict(),
+        sort_keys=True)
+
+    assert serialized_attr_from_raw == serialized_raw
+    assert serialized_attr_from_map == serialized_raw
+
+def test_typed_and_raw_map_json_serialize():
+    class TypedMap(MapAttribute):
+        test_map = MapAttribute()
+
+    class SomeModel(Model):
+        key = NumberAttribute(hash_key=True)
+        typed_map = TypedMap()
+
+    item = SomeModel(
+        typed_map=TypedMap(test_map={'foo': 'bar'})
+    )
+
+    assert json.dumps({'test_map': {'foo': 'bar'}}) == json.dumps(item.typed_map.as_dict())
+
+def test_attribute_paths_wrapping():
+    class InnerMapAttribute(MapAttribute):
+        test_map = MapAttribute(attr_name='dyn_test_map')
+
+    class MiddleMapAttributeA(MapAttribute):
+        inner_map = InnerMapAttribute(attr_name='dyn_in_map_a')
+
+    class MiddleMapAttributeB(MapAttribute):
+        inner_map = InnerMapAttribute(attr_name='dyn_in_map_b')
+
+    class OuterMapAttribute(MapAttribute):
+        mid_map_a = MiddleMapAttributeA()
+        mid_map_b = MiddleMapAttributeB()
+
+    class MyModel(Model):
+        key = NumberAttribute(hash_key=True)
+        outer_map = OuterMapAttribute(attr_name='dyn_out_map')
+
+    mid_map_a_test_map = MyModel.outer_map.mid_map_a.inner_map.test_map
+    mid_map_b_test_map = MyModel.outer_map.mid_map_b.inner_map.test_map
+
+    assert mid_map_a_test_map.attr_name == 'dyn_test_map'
+    assert mid_map_a_test_map.attr_path == ['dyn_out_map', 'mid_map_a', 'dyn_in_map_a', 'dyn_test_map']
+    assert mid_map_b_test_map.attr_name == 'dyn_test_map'
+    assert mid_map_b_test_map.attr_path == ['dyn_out_map', 'mid_map_b', 'dyn_in_map_b', 'dyn_test_map']


### PR DESCRIPTION
The serialization to dict in model was producing undesired results when using the MapAttribute. The model was coming back with raw data out of Dynamo. Now it returns a dictionary with the type prefixes. This change also, optionally, converts Decimal to int or float. The conversion is the default behavior but can be changed for `to_dict`.