### PR TITLE
Fixes #34 MapAttribute Serialization even when serialize=False

### DIFF
--- a/falcano/model.py
+++ b/falcano/model.py
@@ -617,7 +617,11 @@ class Model(metaclass=MetaModel):
 
             if value is None:
                 continue
-            serialized = attr.serialize(value)
+
+            if isinstance(value, MapAttribute):
+                serialized = value.as_dict()
+            else:
+                serialized = attr.serialize(value)
             if serialized is None and not attr.null and null_check:
                 raise ValueError(f"Attribute '{attr.attr_name}' cannot be None")
 


### PR DESCRIPTION
* When using the `MapAttribute` the value is serialized by falcano even when not required.
* This means the stored data within DynamoDB is not stored correctly and makes items overly-complex to read/use away from falcano and makes items bigger in size than they need to be (additional formatting characters etc)
* From reading the code, the code currently calls the attr.serialize() method on a MapAttribute but doesn't seem to be required.
* Simple code change to not run serialize if the attr is of type MapAttribute
*