### PR TITLE
fix: Adds ProvisionedThroughput to table schema

### DIFF
--- a/falcano/model.py
+++ b/falcano/model.py
@@ -369,6 +369,14 @@ class Model(metaclass=MetaModel):  # pylint: disable=too-many-public-methods
             TABLE_NAME: cls.Meta.table_name,
             BILLING_MODE: cls.Meta.billing_mode
         }
+        
+        # Adds capacity units to table if billing mode is PROVISIONED_THROUGHPUT
+        if cls.Meta.billing_mode != PAY_PER_REQUEST_BILLING_MODE:
+            schema[PROVISIONED_THROUGHPUT] = {
+                READ_CAPACITY_UNITS: cls.Meta.read_capacity_units,
+                WRITE_CAPACITY_UNITS: cls.Meta.write_capacity_units,
+            }
+        
         for attr_name, attr_cls in cls.get_attributes():
             if attr_cls.is_hash_key or attr_cls.is_range_key:
                 schema[ATTR_DEFINITIONS].append({


### PR DESCRIPTION
Was receiving the following error when trying to create a table using billing_mode = "PROVISIONED":

`ClientError: An error occurred (ValidationException) when calling the CreateTable operation: No provisioned throughput specified for the table`

This is the code to reproduce the issue:
```Python
from falcano.attributes import UnicodeAttribute
from falcano.model import Model

class BaseModel(Model):
    class Meta(Model.Meta):
        table_name = "tablename"
        host = 'http://localhost:8000'
        read_capacity_units = 1
        write_capacity_units = 1
        billing_mode = "PROVISIONED"

    pk = UnicodeAttribute(hash_key=True)
    sk = UnicodeAttribute(range_key=True)
```

Although the ProvisionedThroughput key was being added to the index schema, it was not being added to the table schema.