### PR TITLE
Allow region override

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,4 +12,4 @@ ignore-docstrings=yes
 # Ignore imports when computing similarities.
 ignore-imports=no
 
-disable=cyclic-import
+disable=cyclic-import,consider-using-f-string,consider-using-dict-items,arguments-renamed,use-dict-literal

--- a/falcano/model.py
+++ b/falcano/model.py
@@ -183,7 +183,7 @@ class Model(metaclass=MetaModel):  # pylint: disable=too-many-public-methods
         read_timeout_seconds = 5
         billing_mode = PAY_PER_REQUEST_BILLING_MODE
         table_name = os.getenv('DYNAMODB_TABLE')
-        region = os.getenv('FALCANO_REGION_OVERRIDE', os.getenv('AWS_DEFAULT_REGION', 'us-east-1'))
+        region_override = os.getenv('FALCANO_REGION_OVERRIDE', None)
         host = os.getenv('ENDPOINT_URL', None)
         _table = None
         separator = '#'
@@ -201,7 +201,10 @@ class Model(metaclass=MetaModel):  # pylint: disable=too-many-public-methods
             '''
             Setter for the table name
             '''
-            dynamodb = boto3.client('dynamodb', self.region, endpoint_url=self.host)
+            if self.region_override:
+                dynamodb = boto3.client('dynamodb', self.region_override, endpoint_url=self.host)
+            else:
+                dynamodb = boto3.client('dynamodb', endpoint_url=self.host)
             self._table = dynamodb.Table(name)
 
     def _set_defaults(self, _user_instantiated: bool = True) -> None:

--- a/falcano/model.py
+++ b/falcano/model.py
@@ -183,6 +183,7 @@ class Model(metaclass=MetaModel):  # pylint: disable=too-many-public-methods
         read_timeout_seconds = 5
         billing_mode = PAY_PER_REQUEST_BILLING_MODE
         table_name = os.getenv('DYNAMODB_TABLE')
+        region = os.getenv('FALCANO_REGION_OVERRIDE', os.getenv('AWS_DEFAULT_REGION', 'us-east-1'))
         host = os.getenv('ENDPOINT_URL', None)
         _table = None
         separator = '#'
@@ -200,7 +201,7 @@ class Model(metaclass=MetaModel):  # pylint: disable=too-many-public-methods
             '''
             Setter for the table name
             '''
-            dynamodb = boto3.client('dynamodb', endpoint_url=self.host)
+            dynamodb = boto3.client('dynamodb', self.region, endpoint_url=self.host)
             self._table = dynamodb.Table(name)
 
     def _set_defaults(self, _user_instantiated: bool = True) -> None:


### PR DESCRIPTION
Currently, a lambda in us-east-2 cannot query a table in us-east-1. 
Just setting `ENDPOINT_URL` to https://dynamodb.us-east-1.amazonaws.com/ doesn't do the trick, because dynamodb is instantiated in the lambda's default region. The mismatch between endpoint url and region causes a 
```
botocore.exceptions.ClientError: An error occurred (InvalidSignatureException) when calling the GetItem operation: Credential should be scoped to a valid region, not 'us-east-2'.
```